### PR TITLE
test: increased timeout

### DIFF
--- a/test/npm-protocol.js
+++ b/test/npm-protocol.js
@@ -72,12 +72,16 @@ describe('reggie npm server', function() {
       pkg.folder,
       ['publish'],
       function(err, stdout, stderr) {
-        if (err) done(err);
-        helpers.runNpmInDirectory(
-          pkg.folder,
-          ['search', pkg.name],
-          expectPackageFoundInSearch(done, pkg.name)
-        );
+        if (err) return done(err);
+        // Give Reggie server some time to process the published package,
+        // because the response is sent before the processing is done
+        setTimeout(function() {
+          helpers.runNpmInDirectory(
+            pkg.folder,
+            ['search', pkg.name],
+            expectPackageFoundInSearch(done, pkg.name)
+          );
+        }, 200);
       }
     );
   });


### PR DESCRIPTION
Increased timeout in 'searches for a package that is already published'
to prevent occasional failures on Travis CI.
