### PR TITLE
Changed order of res.send.

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,14 +83,14 @@ server.put('/package/:name/:version', function (req, res, next) {
   fs.writeFile(tempPackageFile, req.body, function(err) {
     if (err) {
       console.error("Unexpected error when accepting package upload: " + (err.message || err));
-      return res.send(err, 500);
+      return res.send(500, err);
     }
 
     data.loadPackage(tempPackageFile, name, version, function (err) {
       if (err) {
         console.error("Error loading package from upload: " + (err.message || err));
         fs.unlink(tempPackageFile);
-        return res.send(err, 500);
+        return res.send(500, err);
       }
 
       fs.unlink(tempPackageFile);
@@ -106,7 +106,7 @@ server.del('/package/:name/:version', function (req, res, next) {
   data.deletePackage(name, version, function (err) {
     if (err) {
       console.error("Error deleting package " + name + "@" + version + ": " + (err.message || err));
-      return res.send(err, 500);
+      return res.send(500, err);
     }
     res.send(200);
   });
@@ -374,12 +374,12 @@ function returnPackageByRange (name, range, res) {
   data.openPackageStream(name, version, function (err, stream) {
     if (err) {
       console.error("Error streaming package: " + (err.message || err));
-      res.send(err, 500);
+      res.send(500, err);
     }
     stream
       .pipe(res)
       .on('error', function (err) {
-        res.send(err, 500);
+        res.send(500, err);
       });
   })
 }


### PR DESCRIPTION
Restify api specifies statusCode should come first, as in:

``` js
res.send(500, err)
```

Reference: http://mcavage.me/node-restify/#Response-API

Closes #30.
